### PR TITLE
Display Name & Commands

### DIFF
--- a/api/src/main/java/com/envyful/pixel/hunt/remastered/api/PixelHunt.java
+++ b/api/src/main/java/com/envyful/pixel/hunt/remastered/api/PixelHunt.java
@@ -80,4 +80,6 @@ public interface PixelHunt {
     boolean hasTimedOut();
 
     void spawnParticle(Object o);
+
+    void applyNickname(Object o);
 }

--- a/api/src/main/java/com/envyful/pixel/hunt/remastered/api/PixelHunt.java
+++ b/api/src/main/java/com/envyful/pixel/hunt/remastered/api/PixelHunt.java
@@ -79,4 +79,5 @@ public interface PixelHunt {
      */
     boolean hasTimedOut();
 
+    void spawnParticle(Object o);
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ subprojects {
     apply plugin: 'java'
 
     group = 'com.envyful.pixel.hunt.remastered'
-    version = '3.0.2'
+    version = '3.1.0'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8

--- a/forge/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -1,6 +1,5 @@
 package com.envyful.pixel.hunt.remastered.forge.hunt;
 
-import com.envyful.api.config.util.UtilConfig;
 import com.envyful.api.forge.chat.UtilChatColour;
 import com.envyful.api.forge.concurrency.UtilForgeConcurrency;
 import com.envyful.api.forge.items.ItemBuilder;
@@ -21,7 +20,6 @@ import com.google.common.collect.Lists;
 import com.pixelmonmod.pixelmon.Pixelmon;
 import com.pixelmonmod.pixelmon.api.pokemon.Pokemon;
 import com.pixelmonmod.pixelmon.entities.pixelmon.stats.StatsType;
-import com.pixelmonmod.pixelmon.enums.EnumSpecies;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextComponentString;
@@ -179,5 +177,15 @@ public class ForgePixelHunt implements PixelHunt {
         long timePassed = System.currentTimeMillis() - this.currentStart;
 
         return timePassed >= this.duration;
+    }
+
+    @Override
+    public void spawnParticle(Object o) {
+
+    }
+
+    @Override
+    public void applyNickname(Object o) {
+
     }
 }

--- a/forge16/build.gradle
+++ b/forge16/build.gradle
@@ -52,11 +52,11 @@ dependencies {
 
     shadow group: 'org.spongepowered', name: 'configurate-yaml', version: '4.0.0'
 
-    shadow (group: 'com.github.EnvyWare.API', name: 'commons', version: '2.6.9')
-    shadow (group: 'com.github.EnvyWare.API', name: 'forge16', version: '2.6.9') {
+    shadow (group: 'com.github.EnvyWare.API', name: 'commons', version: '2.9.1')
+    shadow (group: 'com.github.EnvyWare.API', name: 'forge16', version: '2.9.1') {
         transitive = false
     }
-    shadow (group: 'com.github.EnvyWare.API', name: 'reforged16', version: '2.6.9') {
+    shadow (group: 'com.github.EnvyWare.API', name: 'reforged16', version: '2.9.1') {
         transitive = false
     }
 

--- a/forge16/build.gradle
+++ b/forge16/build.gradle
@@ -52,11 +52,11 @@ dependencies {
 
     shadow group: 'org.spongepowered', name: 'configurate-yaml', version: '4.0.0'
 
-    shadow (group: 'com.github.EnvyWare.API', name: 'commons', version: '2.6.1')
-    shadow (group: 'com.github.EnvyWare.API', name: 'forge16', version: '2.6.1') {
+    shadow (group: 'com.github.EnvyWare.API', name: 'commons', version: '2.6.9')
+    shadow (group: 'com.github.EnvyWare.API', name: 'forge16', version: '2.6.9') {
         transitive = false
     }
-    shadow (group: 'com.github.EnvyWare.API', name: 'reforged16', version: '2.6.1') {
+    shadow (group: 'com.github.EnvyWare.API', name: 'reforged16', version: '2.6.9') {
         transitive = false
     }
 

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/commands/PixelHuntCommand.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/commands/PixelHuntCommand.java
@@ -16,7 +16,11 @@ import net.minecraft.entity.player.ServerPlayerEntity;
         aliases = {
                "pixelhunt",
                "pokemonhunt",
-               "pokehunt"
+               "pokehunt",
+                "hunts",
+                "pixelhunts",
+                "pokemonhunts",
+                "pokehunts"
         }
 )
 @SubCommands(ReloadCommand.class)

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
@@ -18,21 +18,6 @@ public class PixelHuntConfig extends AbstractYamlConfig {
 
     private ConfigInterface configInterface = new ConfigInterface();
 
-    private List<String> spawnBroadcast = Lists.newArrayList();
-    private List<String> timeoutBroadcast = Lists.newArrayList();
-
-    private String displayName = "&b%species%";
-
-    private List<String> extraLore = Lists.newArrayList(
-            "",
-            "&bTime remaining: %time%"
-    );
-
-    private List<String> preLore = Lists.newArrayList(
-            "",
-            "This goes at the top"
-    );
-
     private boolean enableParticles = true;
 
     private Map<String, HuntConfig> hunts = ImmutableMap.of(
@@ -43,41 +28,33 @@ public class PixelHuntConfig extends AbstractYamlConfig {
         super();
     }
 
-    public List<String> getSpawnBroadcast() {
-        return this.spawnBroadcast;
-    }
-
-    public List<String> getTimeoutBroadcast() {
-        return this.timeoutBroadcast;
-    }
-
     public ConfigInterface getConfigInterface() {
         return this.configInterface;
-    }
-
-    public String getDisplayName() {
-        return this.displayName;
-    }
-
-    public List<String> getExtraLore() {
-        return this.extraLore;
-    }
-
-    public List<String> getPreLore() {
-        return this.preLore;
-    }
-
-    public Map<String, HuntConfig> getHunts() {
-        return this.hunts;
     }
 
     public boolean isEnableParticles() {
         return this.enableParticles;
     }
 
+    public Map<String, HuntConfig> getHunts() {
+        return this.hunts;
+    }
+
     @ConfigSerializable
     public static class HuntConfig {
 
+        private String displayName = "&b%species%";
+        private List<String> extraLore = Lists.newArrayList(
+                "",
+                "&bTime remaining: %time%"
+        );
+
+        private List<String> preLore = Lists.newArrayList(
+                "",
+                "This goes at the top"
+        );
+        private List<String> spawnBroadcast = Lists.newArrayList();
+        private List<String> timeoutBroadcast = Lists.newArrayList();
         private List<String> rewardCommands = Lists.newArrayList("broadcast Testing %player%");
         private List<String> rewardDescription = Lists.newArrayList("Hello");
         private PokemonGeneratorConfig generatorConfig = new PokemonGeneratorConfig(
@@ -95,6 +72,26 @@ public class PixelHuntConfig extends AbstractYamlConfig {
         private int guiY = 1;
 
         public HuntConfig() {}
+
+        public String getDisplayName() {
+            return this.displayName;
+        }
+
+        public List<String> getExtraLore() {
+            return this.extraLore;
+        }
+
+        public List<String> getPreLore() {
+            return this.preLore;
+        }
+
+        public List<String> getSpawnBroadcast() {
+            return this.spawnBroadcast;
+        }
+
+        public List<String> getTimeoutBroadcast() {
+            return this.timeoutBroadcast;
+        }
 
         public List<String> getRewardCommands() {
             return this.rewardCommands;

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
@@ -58,6 +58,8 @@ public class PixelHuntConfig extends AbstractYamlConfig {
                 "",
                 "This goes at the top"
         );
+        private String descriptionColour = "§a";
+        private String descriptionOffColour = "§b";
         private IParticleData particles = ParticleTypes.FLAME;
         private List<String> spawnBroadcast = Lists.newArrayList();
         private List<String> timeoutBroadcast = Lists.newArrayList();
@@ -89,6 +91,14 @@ public class PixelHuntConfig extends AbstractYamlConfig {
 
         public List<String> getPreLore() {
             return this.preLore;
+        }
+
+        public String getDescriptionColour() {
+            return this.descriptionColour;
+        }
+
+        public String getDescriptionOffColour() {
+            return this.descriptionOffColour;
         }
 
         public IParticleData getParticles() {

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
@@ -58,6 +58,7 @@ public class PixelHuntConfig extends AbstractYamlConfig {
                 "",
                 "This goes at the top"
         );
+        private String pokemonNickname = "&6> &r%species% &6<";
         private String descriptionColour = "§a";
         private String descriptionOffColour = "§b";
         private IParticleData particles = ParticleTypes.FLAME;
@@ -91,6 +92,10 @@ public class PixelHuntConfig extends AbstractYamlConfig {
 
         public List<String> getPreLore() {
             return this.preLore;
+        }
+
+        public String getPokemonNickname() {
+            return this.pokemonNickname;
         }
 
         public String getDescriptionColour() {

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
@@ -58,7 +58,7 @@ public class PixelHuntConfig extends AbstractYamlConfig {
                 "",
                 "This goes at the top"
         );
-        private String pokemonNickname = "&6> &r%species% &6<";
+        private String pokemonNickname = "§6> §f%species% §6<";
         private String descriptionColour = "§a";
         private String descriptionOffColour = "§b";
         private IParticleData particles = ParticleTypes.FLAME;

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
@@ -64,6 +64,7 @@ public class PixelHuntConfig extends AbstractYamlConfig {
         private IParticleData particles = ParticleTypes.FLAME;
         private List<String> spawnBroadcast = Lists.newArrayList();
         private List<String> timeoutBroadcast = Lists.newArrayList();
+        private List<String> rewardBroadcast = Lists.newArrayList("broadcast Rewarded %player%");
         private List<String> rewardCommands = Lists.newArrayList("broadcast Testing %player%");
         private List<String> rewardDescription = Lists.newArrayList("Hello");
         private PokemonGeneratorConfig generatorConfig = new PokemonGeneratorConfig(
@@ -116,6 +117,10 @@ public class PixelHuntConfig extends AbstractYamlConfig {
 
         public List<String> getTimeoutBroadcast() {
             return this.timeoutBroadcast;
+        }
+
+        public List<String> getRewardBroadcast() {
+            return this.rewardBroadcast;
         }
 
         public List<String> getRewardCommands() {

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
@@ -1,12 +1,16 @@
 package com.envyful.pixel.hunt.remastered.forge.config;
 
 import com.envyful.api.config.data.ConfigPath;
+import com.envyful.api.config.data.Serializers;
 import com.envyful.api.config.type.ConfigInterface;
 import com.envyful.api.config.yaml.AbstractYamlConfig;
 import com.envyful.api.reforged.pixelmon.config.PokemonGeneratorConfig;
+import com.envyful.pixel.hunt.remastered.forge.config.typeadapter.ParticleDataTypeAdapter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import net.minecraft.particles.IParticleData;
+import net.minecraft.particles.ParticleTypes;
 import org.spongepowered.configurate.objectmapping.ConfigSerializable;
 
 import java.util.List;
@@ -14,6 +18,7 @@ import java.util.Map;
 
 @ConfigPath("config/PixelHuntRemastered/config.yml")
 @ConfigSerializable
+@Serializers(ParticleDataTypeAdapter.class)
 public class PixelHuntConfig extends AbstractYamlConfig {
 
     private ConfigInterface configInterface = new ConfigInterface();
@@ -53,6 +58,7 @@ public class PixelHuntConfig extends AbstractYamlConfig {
                 "",
                 "This goes at the top"
         );
+        private IParticleData particles = ParticleTypes.FLAME;
         private List<String> spawnBroadcast = Lists.newArrayList();
         private List<String> timeoutBroadcast = Lists.newArrayList();
         private List<String> rewardCommands = Lists.newArrayList("broadcast Testing %player%");
@@ -83,6 +89,10 @@ public class PixelHuntConfig extends AbstractYamlConfig {
 
         public List<String> getPreLore() {
             return this.preLore;
+        }
+
+        public IParticleData getParticles() {
+            return this.particles;
         }
 
         public List<String> getSpawnBroadcast() {

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/PixelHuntConfig.java
@@ -21,6 +21,8 @@ public class PixelHuntConfig extends AbstractYamlConfig {
     private List<String> spawnBroadcast = Lists.newArrayList();
     private List<String> timeoutBroadcast = Lists.newArrayList();
 
+    private String displayName = "&b%species%";
+
     private List<String> extraLore = Lists.newArrayList(
             "",
             "&bTime remaining: %time%"
@@ -51,6 +53,10 @@ public class PixelHuntConfig extends AbstractYamlConfig {
 
     public ConfigInterface getConfigInterface() {
         return this.configInterface;
+    }
+
+    public String getDisplayName() {
+        return this.displayName;
     }
 
     public List<String> getExtraLore() {

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/typeadapter/ParticleDataTypeAdapter.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/config/typeadapter/ParticleDataTypeAdapter.java
@@ -1,0 +1,26 @@
+package com.envyful.pixel.hunt.remastered.forge.config.typeadapter;
+
+import com.pixelmonmod.pixelmon.api.util.helpers.ResourceLocationHelper;
+import net.minecraft.particles.IParticleData;
+import net.minecraft.util.registry.Registry;
+import org.spongepowered.configurate.serialize.ScalarSerializer;
+import org.spongepowered.configurate.serialize.SerializationException;
+
+import java.lang.reflect.Type;
+import java.util.function.Predicate;
+
+public class ParticleDataTypeAdapter extends ScalarSerializer<IParticleData> {
+    public ParticleDataTypeAdapter() {
+        super(IParticleData.class);
+    }
+
+    @Override
+    public IParticleData deserialize(Type type, Object obj) throws SerializationException {
+        return (IParticleData) Registry.PARTICLE_TYPE.get(ResourceLocationHelper.of(obj.toString()));
+    }
+
+    @Override
+    protected Object serialize(IParticleData item, Predicate<Class<?>> typeSupported) {
+        return item.getType().getRegistryName().toString();
+    }
+}

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -12,7 +12,6 @@ import com.envyful.api.reforged.pixelmon.PokemonGenerator;
 import com.envyful.api.reforged.pixelmon.PokemonSpec;
 import com.envyful.api.time.UtilTimeFormat;
 import com.envyful.pixel.hunt.remastered.api.PixelHunt;
-import com.envyful.pixel.hunt.remastered.forge.PixelHuntForge;
 import com.envyful.pixel.hunt.remastered.forge.config.PixelHuntConfig;
 import com.envyful.pixel.hunt.remastered.forge.event.PixelHuntStartEvent;
 import com.envyful.pixel.hunt.remastered.forge.event.PixelHuntWonEvent;
@@ -37,6 +36,7 @@ public class ForgePixelHunt implements PixelHunt {
     private final List<String> rewardCommands = Lists.newArrayList();
     private final List<String> rewardDescription = Lists.newArrayList();
 
+    private final PixelHuntConfig.HuntConfig huntConfig;
     private PokemonGenerator generator;
     private ItemStack displayItem;
     private PokemonSpec currentPokemon;
@@ -50,6 +50,7 @@ public class ForgePixelHunt implements PixelHunt {
     private int guiY;
 
     public ForgePixelHunt(PixelHuntConfig.HuntConfig huntConfig) {
+        this.huntConfig = huntConfig;
         this.generator = new PokemonGenerator(huntConfig.getGeneratorConfig());
         this.randomCommands = huntConfig.isRandomCommands();
         this.maxIvs = huntConfig.isMaxIvs();
@@ -69,16 +70,17 @@ public class ForgePixelHunt implements PixelHunt {
     public void display(Pane pane) {
         ItemBuilder builder = new ItemBuilder(this.displayItem.copy());
 
-        builder.name(UtilChatColour.translateColourCodes('&', PixelHuntForge.getInstance().getConfig().getDisplayName().replace("%species%", this.currentPokemon.getDisplayName())));
+        builder.name(UtilChatColour.translateColourCodes('&',
+                this.huntConfig.getDisplayName().replace("%species%", this.currentPokemon.getDisplayName())));
 
-        for (String s : PixelHuntForge.getInstance().getConfig().getPreLore()) {
+        for (String s : this.huntConfig.getPreLore()) {
             builder.addLore(UtilChatColour.translateColourCodes('&', s.replace("%time%",
                                                                                UtilTimeFormat.getFormattedDuration((this.currentStart + this.duration) - System.currentTimeMillis()))));
         }
 
         builder.lore(this.currentPokemon.getDescription("§a", "§b").stream().map(StringTextComponent::new).collect(Collectors.toList()));
 
-        for (String s : PixelHuntForge.getInstance().getConfig().getExtraLore()) {
+        for (String s : this.huntConfig.getExtraLore()) {
             builder.addLore(UtilChatColour.translateColourCodes('&', s.replace("%time%",
                     UtilTimeFormat.getFormattedDuration((this.currentStart + this.duration) - System.currentTimeMillis()))));
         }
@@ -100,7 +102,7 @@ public class ForgePixelHunt implements PixelHunt {
         this.currentStart = System.currentTimeMillis();
         this.currentPokemon = event.getGeneratedPokemon();
 
-        for (String broadcast : PixelHuntForge.getInstance().getConfig().getSpawnBroadcast()) {
+        for (String broadcast : this.huntConfig.getSpawnBroadcast()) {
             ServerLifecycleHooks.getCurrentServer().getPlayerList().broadcastMessage(
                     new StringTextComponent(UtilChatColour.translateColourCodes('&', broadcast
                             .replace("%pokemon%", this.currentPokemon.getDisplayName()))), ChatType.CHAT, Util.NIL_UUID);
@@ -169,7 +171,7 @@ public class ForgePixelHunt implements PixelHunt {
             return;
         }
 
-        for (String message : PixelHuntForge.getInstance().getConfig().getTimeoutBroadcast()) {
+        for (String message : this.huntConfig.getTimeoutBroadcast()) {
             ServerLifecycleHooks.getCurrentServer().getPlayerList()
                     .broadcastMessage(new StringTextComponent(UtilChatColour.translateColourCodes('&',
                             message.replace("%pokemon%",

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -81,7 +81,7 @@ public class ForgePixelHunt implements PixelHunt {
         }
 
         for (String s : this.currentPokemon.getDescription(this.huntConfig.getDescriptionColour(), this.huntConfig.getDescriptionOffColour())) {
-            builder.lore(UtilChatColour.colour(s));
+            builder.addLore(UtilChatColour.colour(s));
         }
 
         for (String s : this.huntConfig.getExtraLore()) {

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -90,7 +90,7 @@ public class ForgePixelHunt implements PixelHunt {
         }
 
         for (String s : this.rewardDescription) {
-            builder.addLore(s);
+            builder.addLore(UtilChatColour.colour(s));
         }
 
         pane.set(this.guiX, this.guiY, GuiFactory.displayableBuilder(ItemStack.class)

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -22,10 +22,8 @@ import com.pixelmonmod.pixelmon.entities.pixelmon.PixelmonEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Util;
-import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.util.text.ChatType;
 import net.minecraft.util.text.ITextComponent;
-import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import org.spongepowered.configurate.ConfigurationNode;
 
@@ -190,11 +188,7 @@ public class ForgePixelHunt implements PixelHunt {
 
         PixelmonEntity pixelmon = (PixelmonEntity) o;
 
-        ServerWorld worldServer = (ServerWorld) pixelmon.level;
-        Vector3d positionVector = pixelmon.position();
-
-        worldServer.addParticle(this.huntConfig.getParticles(),
-                positionVector.x, positionVector.y, positionVector.z,
+        pixelmon.level.addParticle(this.huntConfig.getParticles(), pixelmon.getX(), pixelmon.getY(), pixelmon.getZ(),
                 5, 0, 0.05);
     }
 

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -24,6 +24,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.Util;
 import net.minecraft.util.text.ChatType;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import org.spongepowered.configurate.ConfigurationNode;
 
@@ -188,8 +189,18 @@ public class ForgePixelHunt implements PixelHunt {
 
         PixelmonEntity pixelmon = (PixelmonEntity) o;
 
-        pixelmon.level.addParticle(this.huntConfig.getParticles(), pixelmon.getX(), pixelmon.getY(), pixelmon.getZ(),
-                5, 0, 0.05);
+        ServerWorld serverWorld = (ServerWorld) pixelmon.level;
+
+        serverWorld.sendParticles(this.huntConfig.getParticles(),
+                pixelmon.getX(),
+                pixelmon.getY(),
+                pixelmon.getZ(),
+                1,
+                serverWorld.random.nextDouble() - 0.5,
+                serverWorld.random.nextDouble() - 0.5,
+                serverWorld.random.nextDouble() - 0.5,
+                1
+        );
     }
 
     @Override

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -205,6 +205,10 @@ public class ForgePixelHunt implements PixelHunt {
         }
 
         PixelmonEntity pixelmon = (PixelmonEntity) o;
+        if (pixelmon.hasOwner()) {
+            return;
+        }
+
         ITextComponent nickname = UtilChatColour.colour(this.huntConfig.getPokemonNickname().replace("%species%",
                 pixelmon.getLocalizedName()));
         pixelmon.getPokemon().setNickname(nickname);

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -89,7 +89,9 @@ public class ForgePixelHunt implements PixelHunt {
                     UtilTimeFormat.getFormattedDuration((this.currentStart + this.duration) - System.currentTimeMillis()))));
         }
 
-        builder.addLore(UtilChatColour.translateColourCodes('&', this.rewardDescription).toArray(new String[0]));
+        for (String s : this.rewardDescription) {
+            builder.addLore(s);
+        }
 
         pane.set(this.guiX, this.guiY, GuiFactory.displayableBuilder(ItemStack.class)
                 .itemStack(builder.build()).build());

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -32,7 +32,6 @@ import org.spongepowered.configurate.ConfigurationNode;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 public class ForgePixelHunt implements PixelHunt {
 
@@ -80,7 +79,9 @@ public class ForgePixelHunt implements PixelHunt {
                                                                                UtilTimeFormat.getFormattedDuration((this.currentStart + this.duration) - System.currentTimeMillis()))));
         }
 
-        builder.lore(this.currentPokemon.getDescription("§a", "§b").stream().map(StringTextComponent::new).collect(Collectors.toList()));
+        for (String s : this.currentPokemon.getDescription(this.huntConfig.getDescriptionColour(), this.huntConfig.getDescriptionOffColour())) {
+            builder.lore(UtilChatColour.colour(s));
+        }
 
         for (String s : this.huntConfig.getExtraLore()) {
             builder.addLore(UtilChatColour.translateColourCodes('&', s.replace("%time%",

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -19,11 +19,14 @@ import com.google.common.collect.Lists;
 import com.pixelmonmod.pixelmon.Pixelmon;
 import com.pixelmonmod.pixelmon.api.pokemon.Pokemon;
 import com.pixelmonmod.pixelmon.api.pokemon.stats.BattleStatsType;
+import com.pixelmonmod.pixelmon.entities.pixelmon.PixelmonEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.Util;
+import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.util.text.ChatType;
 import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
 import org.spongepowered.configurate.ConfigurationNode;
 
@@ -70,8 +73,7 @@ public class ForgePixelHunt implements PixelHunt {
     public void display(Pane pane) {
         ItemBuilder builder = new ItemBuilder(this.displayItem.copy());
 
-        builder.name(UtilChatColour.translateColourCodes('&',
-                this.huntConfig.getDisplayName().replace("%species%", this.currentPokemon.getDisplayName())));
+        builder.name(UtilChatColour.colour(this.huntConfig.getDisplayName().replace("%species%", this.currentPokemon.getDisplayName())));
 
         for (String s : this.huntConfig.getPreLore()) {
             builder.addLore(UtilChatColour.translateColourCodes('&', s.replace("%time%",
@@ -184,5 +186,21 @@ public class ForgePixelHunt implements PixelHunt {
         long timePassed = System.currentTimeMillis() - this.currentStart;
 
         return timePassed >= this.duration;
+    }
+
+    @Override
+    public void spawnParticle(Object o) {
+        if (!(o instanceof PixelmonEntity)) {
+            return;
+        }
+
+        PixelmonEntity pixelmon = (PixelmonEntity) o;
+
+        ServerWorld worldServer = (ServerWorld) pixelmon.level;
+        Vector3d positionVector = pixelmon.position();
+
+        worldServer.addParticle(this.huntConfig.getParticles(),
+                positionVector.x, positionVector.y, positionVector.z,
+                5, 0, 0.05);
     }
 }

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -25,6 +25,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.vector.Vector3d;
 import net.minecraft.util.text.ChatType;
+import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.fml.server.ServerLifecycleHooks;
@@ -203,5 +204,16 @@ public class ForgePixelHunt implements PixelHunt {
         worldServer.addParticle(this.huntConfig.getParticles(),
                 positionVector.x, positionVector.y, positionVector.z,
                 5, 0, 0.05);
+    }
+
+    @Override
+    public void applyNickname(Object o) {
+        if (!(o instanceof PixelmonEntity)) {
+            return;
+        }
+
+        PixelmonEntity pixelmon = (PixelmonEntity) o;
+        ITextComponent nickname = UtilChatColour.colour(this.huntConfig.getPokemonNickname().replace("%species%", pixelmon.getLocalizedName()));
+        pixelmon.getPokemon().setNickname(nickname);
     }
 }

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -85,7 +85,7 @@ public class ForgePixelHunt implements PixelHunt {
         }
 
         for (String s : this.huntConfig.getExtraLore()) {
-            builder.addLore(UtilChatColour.translateColourCodes('&', s.replace("%time%",
+            builder.addLore(UtilChatColour.colour(s.replace("%time%",
                     UtilTimeFormat.getFormattedDuration((this.currentStart + this.duration) - System.currentTimeMillis()))));
         }
 

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -141,15 +141,15 @@ public class ForgePixelHunt implements PixelHunt {
             }
         }
 
-        UtilForgeConcurrency.runSync(() -> {
-            // TODO: if empty?
-            for (String broadcast : this.huntConfig.getRewardBroadcast()) {
-                ServerLifecycleHooks.getCurrentServer().getPlayerList().broadcastMessage(
-                        UtilChatColour.colour(broadcast.replace("%pokemon%", this.currentPokemon.getDisplayName())),
-                        ChatType.CHAT, Util.NIL_UUID
-                );
-            }
+        for (String broadcast : this.huntConfig.getRewardBroadcast()) {
+            ServerLifecycleHooks.getCurrentServer().getPlayerList().broadcastMessage(
+                    UtilChatColour.colour(broadcast
+                            .replace("%pokemon%", this.currentPokemon.getDisplayName())
+                            .replace("%player%", parent.getName().toString())), ChatType.CHAT, Util.NIL_UUID
+            );
+        }
 
+        UtilForgeConcurrency.runSync(() -> {
             if (this.huntConfig.isRandomCommands()) {
                 UtilForgeServer.executeCommand(UtilRandom.getRandomElement(this.huntConfig.getRewardCommands())
                         .replace("%player%", parent.getName().getString()));
@@ -205,7 +205,8 @@ public class ForgePixelHunt implements PixelHunt {
         }
 
         PixelmonEntity pixelmon = (PixelmonEntity) o;
-        ITextComponent nickname = UtilChatColour.colour(this.huntConfig.getPokemonNickname().replace("%species%", pixelmon.getLocalizedName()));
+        ITextComponent nickname = UtilChatColour.colour(this.huntConfig.getPokemonNickname().replace("%species%",
+                pixelmon.getLocalizedName()));
         pixelmon.getPokemon().setNickname(nickname);
     }
 }

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -145,7 +145,7 @@ public class ForgePixelHunt implements PixelHunt {
             ServerLifecycleHooks.getCurrentServer().getPlayerList().broadcastMessage(
                     UtilChatColour.colour(broadcast
                             .replace("%pokemon%", this.currentPokemon.getDisplayName())
-                            .replace("%player%", parent.getName().toString())), ChatType.CHAT, Util.NIL_UUID
+                            .replace("%player%", parent.getName().getString())), ChatType.CHAT, Util.NIL_UUID
             );
         }
 

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/hunt/ForgePixelHunt.java
@@ -69,6 +69,8 @@ public class ForgePixelHunt implements PixelHunt {
     public void display(Pane pane) {
         ItemBuilder builder = new ItemBuilder(this.displayItem.copy());
 
+        builder.name(UtilChatColour.translateColourCodes('&', PixelHuntForge.getInstance().getConfig().getDisplayName().replace("%species%", this.currentPokemon.getDisplayName())));
+
         for (String s : PixelHuntForge.getInstance().getConfig().getPreLore()) {
             builder.addLore(UtilChatColour.translateColourCodes('&', s.replace("%time%",
                                                                                UtilTimeFormat.getFormattedDuration((this.currentStart + this.duration) - System.currentTimeMillis()))));

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/listener/PokemonCaptureListener.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/listener/PokemonCaptureListener.java
@@ -28,12 +28,12 @@ public class PokemonCaptureListener {
             Pokemon caught = event.getPokemon().getPokemon();
             ServerPlayerEntity player = event.player;
             ForgeEnvyPlayer envyPlayer = this.mod.getPlayerManager().getPlayer(player);
-            caught.removeNickname();
 
             for (PixelHunt hunt : PixelHuntFactory.getAllHunts()) {
                 if (hunt.isBeingHunted(caught)) {
                     hunt.rewardCatch(envyPlayer, caught);
                     hunt.generatePokemon();
+                    caught.removeNickname();
                     break;
                 }
             }
@@ -47,12 +47,12 @@ public class PokemonCaptureListener {
             Pokemon caught = event.getRaidPokemon();
             ServerPlayerEntity player = event.player;
             ForgeEnvyPlayer envyPlayer = this.mod.getPlayerManager().getPlayer(player);
-            caught.removeNickname();
 
             for (PixelHunt hunt : PixelHuntFactory.getAllHunts()) {
                 if (hunt.isBeingHunted(caught)) {
                     hunt.rewardCatch(envyPlayer, caught);
                     hunt.generatePokemon();
+                    caught.removeNickname();
                     break;
                 }
             }

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/listener/PokemonCaptureListener.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/listener/PokemonCaptureListener.java
@@ -33,6 +33,7 @@ public class PokemonCaptureListener {
                 if (hunt.isBeingHunted(caught)) {
                     hunt.rewardCatch(envyPlayer, caught);
                     hunt.generatePokemon();
+                    caught.setNickname(caught.getLocalizedName());
                     break;
                 }
             }
@@ -51,6 +52,7 @@ public class PokemonCaptureListener {
                 if (hunt.isBeingHunted(caught)) {
                     hunt.rewardCatch(envyPlayer, caught);
                     hunt.generatePokemon();
+                    caught.setNickname(caught.getLocalizedName());
                     break;
                 }
             }

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/listener/PokemonCaptureListener.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/listener/PokemonCaptureListener.java
@@ -24,6 +24,7 @@ public class PokemonCaptureListener {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onPokemonCaught(CaptureEvent.SuccessfulCapture event) {
+        event.getPokemon().getPokemon().removeNickname();
         UtilConcurrency.runAsync(() -> {
             Pokemon caught = event.getPokemon().getPokemon();
             ServerPlayerEntity player = event.player;
@@ -33,7 +34,6 @@ public class PokemonCaptureListener {
                 if (hunt.isBeingHunted(caught)) {
                     hunt.rewardCatch(envyPlayer, caught);
                     hunt.generatePokemon();
-                    caught.removeNickname();
                     break;
                 }
             }
@@ -43,6 +43,7 @@ public class PokemonCaptureListener {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void onPokemonCaught(CaptureEvent.SuccessfulRaidCapture event) {
+        event.getPokemon().getPokemon().removeNickname();
         UtilConcurrency.runAsync(() -> {
             Pokemon caught = event.getRaidPokemon();
             ServerPlayerEntity player = event.player;
@@ -52,7 +53,6 @@ public class PokemonCaptureListener {
                 if (hunt.isBeingHunted(caught)) {
                     hunt.rewardCatch(envyPlayer, caught);
                     hunt.generatePokemon();
-                    caught.removeNickname();
                     break;
                 }
             }

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/listener/PokemonCaptureListener.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/listener/PokemonCaptureListener.java
@@ -28,12 +28,12 @@ public class PokemonCaptureListener {
             Pokemon caught = event.getPokemon().getPokemon();
             ServerPlayerEntity player = event.player;
             ForgeEnvyPlayer envyPlayer = this.mod.getPlayerManager().getPlayer(player);
+            caught.removeNickname();
 
             for (PixelHunt hunt : PixelHuntFactory.getAllHunts()) {
                 if (hunt.isBeingHunted(caught)) {
                     hunt.rewardCatch(envyPlayer, caught);
                     hunt.generatePokemon();
-                    caught.setNickname(caught.getLocalizedName());
                     break;
                 }
             }
@@ -47,12 +47,12 @@ public class PokemonCaptureListener {
             Pokemon caught = event.getRaidPokemon();
             ServerPlayerEntity player = event.player;
             ForgeEnvyPlayer envyPlayer = this.mod.getPlayerManager().getPlayer(player);
+            caught.removeNickname();
 
             for (PixelHunt hunt : PixelHuntFactory.getAllHunts()) {
                 if (hunt.isBeingHunted(caught)) {
                     hunt.rewardCatch(envyPlayer, caught);
                     hunt.generatePokemon();
-                    caught.setNickname(caught.getLocalizedName());
                     break;
                 }
             }

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/listener/PokemonSpawnListener.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/listener/PokemonSpawnListener.java
@@ -39,6 +39,7 @@ public class PokemonSpawnListener extends LazyListener {
             for (PixelHunt hunt : PixelHuntFactory.getAllHunts()) {
                 if (hunt.isSpeciesHunted(pixelmon.getPokemon())) {
                     ParticleDisplayTask.addPokemon(pixelmon);
+                    hunt.applyNickname(pixelmon);
                     return;
                 }
             }

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/listener/PokemonSpawnListener.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/listener/PokemonSpawnListener.java
@@ -23,7 +23,7 @@ public class PokemonSpawnListener extends LazyListener {
 
     @SubscribeEvent
     public void onPokemonSpawn(EntityJoinWorldEvent event) {
-        if (!PixelHuntForge.getInstance().getConfig().isEnableParticles()) {
+        if (!this.mod.getConfig().isEnableParticles()) {
             return;
         }
 

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/task/ParticleDisplayTask.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/task/ParticleDisplayTask.java
@@ -60,7 +60,6 @@ public class ParticleDisplayTask extends LazyListener {
                 }
             }
 
-
             for (PixelHunt allHunt : PixelHuntFactory.getAllHunts()) {
                 if (allHunt.hasTimedOut()) {
                     allHunt.end();

--- a/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/task/ParticleDisplayTask.java
+++ b/forge16/src/main/java/com/envyful/pixel/hunt/remastered/forge/task/ParticleDisplayTask.java
@@ -6,11 +6,7 @@ import com.envyful.pixel.hunt.remastered.api.PixelHunt;
 import com.envyful.pixel.hunt.remastered.api.PixelHuntFactory;
 import com.envyful.pixel.hunt.remastered.forge.PixelHuntForge;
 import com.google.common.collect.Lists;
-import com.pixelmonmod.pixelmon.api.pokemon.Pokemon;
 import com.pixelmonmod.pixelmon.entities.pixelmon.PixelmonEntity;
-import net.minecraft.particles.ParticleTypes;
-import net.minecraft.util.math.vector.Vector3d;
-import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -48,25 +44,23 @@ public class ParticleDisplayTask extends LazyListener {
         }
 
         Iterator<PixelmonEntity> iterator = this.huntPokemon.iterator();
+        UtilConcurrency.runAsync(() -> {
+            while (iterator.hasNext()) {
+                PixelmonEntity pixelmon = iterator.next();
 
-        while (iterator.hasNext()) {
-            PixelmonEntity pixelmon = iterator.next();
+                if (pixelmon == null || !pixelmon.isAlive() || pixelmon.hasOwner()) {
+                    iterator.remove();
+                    continue;
+                }
 
-            if (pixelmon == null || !pixelmon.isAlive() || pixelmon.hasOwner()
-                    || !this.isHuntPokemon(pixelmon.getPokemon())) {
-                iterator.remove();
-                continue;
+                for (PixelHunt hunt : PixelHuntFactory.getAllHunts()) {
+                    if (hunt.isSpeciesHunted(pixelmon.getPokemon())) {
+                        hunt.spawnParticle(pixelmon);
+                    }
+                }
             }
 
-            ServerWorld worldServer = (ServerWorld)pixelmon.level;
-            Vector3d positionVector = pixelmon.position();
 
-            worldServer.addParticle(ParticleTypes.FLAME,
-                    positionVector.x, positionVector.y, positionVector.z,
-                    5, 0, 0.05);
-        }
-
-        UtilConcurrency.runAsync(() -> {
             for (PixelHunt allHunt : PixelHuntFactory.getAllHunts()) {
                 if (allHunt.hasTimedOut()) {
                     allHunt.end();
@@ -75,15 +69,4 @@ public class ParticleDisplayTask extends LazyListener {
             }
         });
     }
-
-    private boolean isHuntPokemon(Pokemon pokemon) {
-        for (PixelHunt hunt : PixelHuntFactory.getAllHunts()) {
-            if (hunt.isSpeciesHunted(pokemon)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
 }


### PR DESCRIPTION
- Adds a configurable displayName for each hunt.
- Adds /hunts, /pixelhunts, /pokemonhunts and /pokehunts as command aliases.
- Refactors config to be per hunt compared to global.
- Adds configurable particle effects per hunt.
- Adds configurable custom nickname on spawn. Removes on capture.
- GUI displayName and lore now support hex codes.
- All broadcasts now support hex.
- Added broadcast on hunt completion. 